### PR TITLE
Fix links color in Dark Mode in About view

### DIFF
--- a/gSwitch/Views/About/Base.lproj/AboutWindow.xib
+++ b/gSwitch/Views/About/Base.lproj/AboutWindow.xib
@@ -51,7 +51,7 @@
                         <rect key="frame" x="83" y="33" width="110" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Report a problem" id="Tgz-jQ-mJJ">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="linkColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                         <userDefinedRuntimeAttributes>
@@ -62,7 +62,7 @@
                         <rect key="frame" x="210" y="33" width="48" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Donate" id="Der-db-cFl">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="linkColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                         <userDefinedRuntimeAttributes>


### PR DESCRIPTION
Links have few low contrast in Dark Mode and using linkColor should resolve that (it does in my local Xcode Interface Builder) - and that color should work for Light and Dark themes. This is very much "back of the cabinet type of issue", but I'd love to get it fixed if possible :-)