### PR TITLE
String suggestions

### DIFF
--- a/gSwitch/Views/Preferences/en.lproj/PreferencesWindow.strings
+++ b/gSwitch/Views/Preferences/en.lproj/PreferencesWindow.strings
@@ -2,20 +2,20 @@
 /* Class = "NSButtonCell"; title = "Open Advanced Pane"; ObjectID = "0Kj-h1-2n7"; */
 "0Kj-h1-2n7.title" = "Open Advanced Pane";
 
-/* Class = "NSButtonCell"; title = "Automatically Update"; ObjectID = "DeE-7M-miq"; */
-"DeE-7M-miq.title" = "Automatically Update";
+/* Class = "NSButtonCell"; title = "Automatically update"; ObjectID = "DeE-7M-miq"; */
+"DeE-7M-miq.title" = "Automatically update";
 
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Preferences";
 
-/* Class = "NSButtonCell"; title = "Start At Login"; ObjectID = "MkE-JC-o7C"; */
-"MkE-JC-o7C.title" = "Start At Login";
+/* Class = "NSButtonCell"; title = "Start at login"; ObjectID = "MkE-JC-o7C"; */
+"MkE-JC-o7C.title" = "Start at Login";
 
-/* Class = "NSButtonCell"; title = "Check For Updates"; ObjectID = "RkS-5e-LJU"; */
-"RkS-5e-LJU.title" = "Check For Updates";
+/* Class = "NSButtonCell"; title = "Check for updates"; ObjectID = "RkS-5e-LJU"; */
+"RkS-5e-LJU.title" = "Check for updates";
 
-/* Class = "NSButtonCell"; title = "Remember Last GPU Mode"; ObjectID = "bFW-cw-Q0d"; */
-"bFW-cw-Q0d.title" = "Remember Last GPU Mode";
+/* Class = "NSButtonCell"; title = "Remember last GPU mode"; ObjectID = "bFW-cw-Q0d"; */
+"bFW-cw-Q0d.title" = "Remember last GPU mode";
 
-/* Class = "NSButtonCell"; title = "Show GPU Change Notifications"; ObjectID = "gou-CF-jiG"; */
-"gou-CF-jiG.title" = "Show GPU Change Notifications";
+/* Class = "NSButtonCell"; title = "Show GPU change notifications"; ObjectID = "gou-CF-jiG"; */
+"gou-CF-jiG.title" = "Show GPU change notifications";

--- a/gSwitch/Views/Preferences/en.lproj/PreferencesWindow.strings
+++ b/gSwitch/Views/Preferences/en.lproj/PreferencesWindow.strings
@@ -8,7 +8,7 @@
 /* Class = "NSWindow"; title = "Preferences"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Preferences";
 
-/* Class = "NSButtonCell"; title = "Start at login"; ObjectID = "MkE-JC-o7C"; */
+/* Class = "NSButtonCell"; title = "Start at Login"; ObjectID = "MkE-JC-o7C"; */
 "MkE-JC-o7C.title" = "Start at Login";
 
 /* Class = "NSButtonCell"; title = "Check for updates"; ObjectID = "RkS-5e-LJU"; */


### PR DESCRIPTION
Based on Apple's usage of strings on macOS, I'm proposing some changes to the strings at the Preferences pane. Others seem fine.

# Apple's usages
### `Automatically update` and `Check for updates` (Check for updates in lowercase)
<img width="780" alt="Screen Shot 2020-06-24 at 21 15 26" src="https://user-images.githubusercontent.com/17576065/85610648-d92d6280-b65f-11ea-8c7c-264eb8ca58bf.png">

### `Start at Login`
<img width="198" alt="Screen Shot 2020-06-24 at 21 16 44" src="https://user-images.githubusercontent.com/17576065/85610808-02e68980-b660-11ea-9453-0deaf67ff1c3.png">

### `Remember last GPU mode` and `Show GPU change notifications`
Most words that are not nouns are used lowercase throughout macOS. These should be lowercase as well because of that.

## Notes
- Other translations not updated, because it requires discussion.
- I may have changed special names that need further changes in other files, please warn if I did (e.g. title=).