### PR TITLE
Update README with new brew cask usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then after unzipping move the gSwitch.app file to your applications folder.
 ### With Brew
 
 ```bash
-brew cask install gswitch
+brew install gswitch
 ```
 
 ### From Source


### PR DESCRIPTION
`brew cask install` is deprecated. Instead `brew install` should be used.