### PR TITLE
Update brew setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then after unzipping move the gSwitch.app file to your applications folder.
 ### With Brew
 
 ```bash
-brew cask install gswitch
+brew install --cask gswitch
 ```
 
 ### From Source


### PR DESCRIPTION
Fix the installation via brew since calling brew cask install [formula] is not supported anymore.